### PR TITLE
Make properties for script installation accessible from recipe

### DIFF
--- a/attributes/bazel.rb
+++ b/attributes/bazel.rb
@@ -4,3 +4,5 @@ default.java.jdk_version = 8
 default.bazel.version = '0.3.0'
 default.bazel.prefix = '/usr/local'
 default.bazel.installation_method = nil  # automatic
+
+default.bazel.installation_script = {}

--- a/recipes/bazel.rb
+++ b/recipes/bazel.rb
@@ -27,6 +27,9 @@ when 'script'
   include_recipe 'zip' unless node.platform_family == 'mac_os_x'
   bazel_installation_script 'bazel' do
     action :create
+    node.bazel.installation_script.each do |name, value|
+      send(name, value)
+    end
   end
 else
   include_recipe 'zip' unless node.platform_family == 'mac_os_x'


### PR DESCRIPTION
Added an attribute to configure bazel_installation_script resource in
the default recipe
